### PR TITLE
Stabilize testMultiThreadsUpdate

### DIFF
--- a/metrics-core-impl/src/test/java/com/alibaba/metrics/BucketCounterTest.java
+++ b/metrics-core-impl/src/test/java/com/alibaba/metrics/BucketCounterTest.java
@@ -78,7 +78,7 @@ public class BucketCounterTest {
         int ROUND = 1;
         for (int r = 0; r < ROUND; r++) {
             System.out.println("Round: " + r);
-            BucketCounter bucketCounter = new BucketCounterImpl(1, 10, Clock.defaultClock());
+            BucketCounter bucketCounter = new BucketCounterImpl(1, 15, Clock.defaultClock());
             BizThread[] bizThreads = new BizThread[80];
             for (int i = 0; i < bizThreads.length; i++) {
                 bizThreads[i] = new BizThread(bucketCounter);


### PR DESCRIPTION
### Summary
`testMultiThreadsUpdate` 可能会因为多线程测试执行时间过长会导致内部 `BucketDeque` 中部分 `Bucket` 被 evict 掉

### Root Cause Analysis
在 jdk11 上有一个失败的构建 https://travis-ci.org/dubbo/dubbo-metrics/jobs/496341442
```
Running com.alibaba.metrics.BucketCounterTest
Round: 0
Tests run: 11, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 25.578 sec <<< FAILURE! - in com.alibaba.metrics.BucketCounterTest
testMultiThreadsUpdate(com.alibaba.metrics.BucketCounterTest)  Time elapsed: 10.067 sec  <<< FAILURE!
java.lang.AssertionError: [800, 7740, 7039, 6301, 5500, 4720, 3940, 3190, 2370, 1600] expected:<44000> but was:<43200>
	at com.alibaba.metrics.BucketCounterTest.testMultiThreadsUpdate(BucketCounterTest.java:108)
Results :
Failed tests: 
  BucketCounterTest.testMultiThreadsUpdate:108 [800, 7740, 7039, 6301, 5500, 4720, 3940, 3190, 2370, 1600] expected:<44000> but was:<43200>

```

本地增加 debug 信息，并尝试复现该问题
在 `BucketCounterImpl#update()` 中增加打印语句
```
            // create a new bucket and evict the oldest one
            Bucket newBucket = new Bucket();
            newBucket.timestamp = curTs;
            if (latestBucket.compareAndSet(oldBucket, newBucket)) {
                // this is a single thread operation
                System.out.println("buckets.addLast():" + newBucket);   // debug info
                buckets.addLast(newBucket);
                oldBucket = newBucket;
            } else {
                oldBucket = latestBucket.get();
            }
```
并执行该用例
```
mvn test -pl metrics-core-impl -Dtest=com.alibaba.metrics.BucketCounterTest#testMultiThreadsUpdate
```

在主机CPU繁忙时可以得到以下输出
```
-----------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.alibaba.metrics.BucketCounterTest
Round: 0
buckets.addLast():com.alibaba.metrics.Bucket@88272c4
buckets.addLast():com.alibaba.metrics.Bucket@4c3ab99d
buckets.addLast():com.alibaba.metrics.Bucket@42fd5e6a
buckets.addLast():com.alibaba.metrics.Bucket@46c2d2ed
buckets.addLast():com.alibaba.metrics.Bucket@3c05451
buckets.addLast():com.alibaba.metrics.Bucket@40c037da
buckets.addLast():com.alibaba.metrics.Bucket@4e07c1b2
buckets.addLast():com.alibaba.metrics.Bucket@4a385caa
buckets.addLast():com.alibaba.metrics.Bucket@f3acb89
buckets.addLast():com.alibaba.metrics.Bucket@4e054353
buckets.addLast():com.alibaba.metrics.Bucket@3eff0170
buckets.addLast():com.alibaba.metrics.Bucket@7ca83f9a
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 13.632 sec <<< FAILURE! - in com.alibaba.metrics.BucketCounterTest
testMultiThreadsUpdate(com.alibaba.metrics.BucketCounterTest)  Time elapsed: 12.36 sec  <<< FAILURE!
java.lang.AssertionError: [400, 3260, 7630, 6830, 6030, 5230, 4430, 2870, 3030, 2230] expected:<44000> but was:<41940>
	at com.alibaba.metrics.BucketCounterTest.testMultiThreadsUpdate(BucketCounterTest.java:108)


Results :

Failed tests: 
  BucketCounterTest.testMultiThreadsUpdate:108 [400, 3260, 7630, 6830, 6030, 5230, 4430, 2870, 3030, 2230] expected:<44000> but was:<41940>

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

```
可以看出，该用例执行了 `12.36s`，并创建了 `12` 个 `Bucket`，由于队列初始大小为 `10`，所以有部分 `Bucket` 被 evict 掉，丢失部分数据导致用例不通过。travis 上环境配置较低更容易复现，本地可以用 cgroup 限制下 CPU 来复现。

### Solution
适当增加该用例中的初始 `BacketDeque` 大小以缓解该问题